### PR TITLE
Update source code link in dashboard to point to uBOL over uBO

### DIFF
--- a/chromium/dashboard.html
+++ b/chromium/dashboard.html
@@ -128,7 +128,7 @@
             </div>
             <div class="li"><a href="https://github.com/gorhill/uBlock/wiki/Privacy-policy" data-i18n="aboutPrivacyPolicy"></a></div>
             <div class="li"><a href="https://github.com/uBlockOrigin/uBOL-home/releases" data-i18n="aboutChangelog"></a></div>
-            <div class="li"><a href="https://github.com/gorhill/uBlock" data-i18n="aboutCode"></a></div>
+            <div class="li"><a href="https://github.com/uBlockOrigin/uBOL-home" data-i18n="aboutCode"></a></div>
             <div class="li"><span data-i18n="aboutContributors"></span></div>
             <div class="liul">
                 <div class="li"><a href="https://github.com/gorhill/uBlock/graphs/contributors" data-i18n="aboutSourceCode"></a></div>

--- a/firefox/dashboard.html
+++ b/firefox/dashboard.html
@@ -128,7 +128,7 @@
             </div>
             <div class="li"><a href="https://github.com/gorhill/uBlock/wiki/Privacy-policy" data-i18n="aboutPrivacyPolicy"></a></div>
             <div class="li"><a href="https://github.com/uBlockOrigin/uBOL-home/releases" data-i18n="aboutChangelog"></a></div>
-            <div class="li"><a href="https://github.com/gorhill/uBlock" data-i18n="aboutCode"></a></div>
+            <div class="li"><a href="https://github.com/uBlockOrigin/uBOL-home" data-i18n="aboutCode"></a></div>
             <div class="li"><span data-i18n="aboutContributors"></span></div>
             <div class="liul">
                 <div class="li"><a href="https://github.com/gorhill/uBlock/graphs/contributors" data-i18n="aboutSourceCode"></a></div>


### PR DESCRIPTION
Currently, the "Source code (GPLv3)" link in the uBOL dashboard points to the source code of the original uBlock Origin rather than uBlock Origin Lite. I have updated the URL to point to this repository

It is unclear whether this was intentional or not, so feel free to close this if the presence of the uBO URL was purposeful