### PR TITLE
Add the possibility to disable the zapper with disabledFeatures in managed options.

### DIFF
--- a/chromium/css/popup.css
+++ b/chromium/css/popup.css
@@ -69,6 +69,9 @@ body[data-forbid~="filteringMode"] .filteringModeSlider {
 body[data-forbid~="dashboard"] #gotoDashboard {
     display: none;
     }
+body[data-forbid~="zapper"] #gotoZapper {
+    display: none;
+    }
 
 .lrspacer {
     padding-left: var(--default-gap-small);


### PR DESCRIPTION
This PR adds the possibility to disable the zapper with disabledFeatures in managed options.

This adds the css-rule:
```css
body[data-forbid~="zapper"] #gotoZapper {
    display: none;
    }
```
to ./chromium/css/popup.css

Thus enabling the disabling of the element zapper through managed policy settings:
```json
{
  "disabledFeatures": {
     "Value": ["zapper"]
}
```