### PR TITLE
Fix typo in README regarding  capitalization and formatting

### DIFF
--- a/firefox/README.md
+++ b/firefox/README.md
@@ -2,10 +2,10 @@
 
 Instructions for reviewers.
 
-The following assumes a linux environment.
+The following assumes a Linux environment.
 
 1. Open Bash console
-2. `git clone  https://github.com/gorhill/uBlock.git`
+2. `git clone https://github.com/gorhill/uBlock.git`
 3. `cd uBlock`
 4. `make mv3-[platform]`, where `[platform]` is either `chromium` or `firefox`
 5. This will fully build uBO Lite, and during the process filter lists will be downloaded from their respective remote servers
@@ -13,7 +13,7 @@ The following assumes a linux environment.
 Upon completion of the script, the resulting extension package will become present in:
 
 - Chromium: `dist/build/uBOLite.chromium`
--  Firefox: `dist/build/uBOLite.firefox`
+- Firefox: `dist/build/uBOLite.firefox`
 
 The folder `dist/build/mv3-data` will cache data fetched from remote server, so as to avoid fetching repeatedly from remote server with repeated build commands. Remove `dist/build/mv3-data` if you want to build with latest versions of filter lists.
 
@@ -21,7 +21,7 @@ The file `dist/build/mv3-data/log.txt` will contain information about what happe
 
 The entry in the `Makefile` which implement the build process is `tools/make-mv3.sh [platform]`.[1] This Bash script copy various files from uBlock Origin branch and MV3-specific branch into a single folder which will be the final extension package.
 
-Notably, `tools/make-mv3.sh [platform]` calls a Nodejs script which purpose is to convert the filter lists into various rulesets to be used in a declarative way. The Nodejs version required is 17.5.0 or above.
+Notably, `tools/make-mv3.sh [platform]` calls a Node.js script which purpose is to convert the filter lists into various rulesets to be used in a declarative way. The Node.js version required is 17.5.0 or above.
 
 All the final rulesets are present in the `dist/build/uBOLite.[platform]/rulesets` in the final extension package.
 


### PR DESCRIPTION
Corrected capitalization and formatting in README.

- Fixed several typos (linux -> Linux, Nodejs -> Node.js)
- There's an extra space between clone and https.
- There's an extra leading space before Firefox:."