### PR TITLE
Fix typo in Greek translation.

### DIFF
--- a/chromium/_locales/el/messages.json
+++ b/chromium/_locales/el/messages.json
@@ -280,7 +280,7 @@
     "description": "Placeholder for the input field used to find lists"
   },
   "strictblockTitle": {
-    "message": "Αποκλησμένη σελίδα",
+    "message": "Αποκλεισμένη σελίδα",
     "description": "Webpage title for the strict-blocked page"
   },
   "strictblockSentence1": {


### PR DESCRIPTION
<img width="880" height="212" alt="image" src="https://github.com/user-attachments/assets/ff1f4a4d-b2d6-4279-a6ef-c149c1eec6b0" />
