### PR TITLE
Show alert when adding invalid custom filters

### DIFF
--- a/chromium/js/filter-manager-ui.js
+++ b/chromium/js/filter-manager-ui.js
@@ -383,7 +383,7 @@ async function importFromText(text) {
         }
     }
 
-    if ( hostnameToSelectorsMap.size === 0 ) { return; }
+    if ( hostnameToSelectorsMap.size === 0 ) { return false; }
 
     dom.cl.add(dom.body, 'readonly');
     updateContentEditability();
@@ -402,15 +402,21 @@ async function importFromText(text) {
     await debounceRenderCustomFilters();
     dom.cl.remove(dom.body, 'readonly');
     updateContentEditability();
+
+    return true;
 }
 
 /******************************************************************************/
 
-function importFromTextarea() {
-    dom.prop('section[data-pane="filters"] details', 'open', false);
+async function importFromTextarea() {
     const textarea = qs$('section[data-pane="filters"] .importFromText textarea');
-    importFromText(textarea.value);
-    textarea.value = '';
+
+    if ( await importFromText(textarea.value) ) {
+        dom.prop('section[data-pane="filters"] details', 'open', false);
+        textarea.value = '';
+    } else {
+        window.alert("No valid rules found");
+    }
 }
 
 /******************************************************************************/


### PR DESCRIPTION
Before this change, when the user tried to add an invalid custom filter manually on `Settings > Custom filters > Import / Export` textarea, the popup would close, clear the field and not give any feedback about whether the filter was applied or not. Now, it shows an alert regarding the issue, keeping the previous input untouched.

<img width="1470" height="874" alt="Screenshot 2026-01-14 at 10 59 29 AM" src="https://github.com/user-attachments/assets/1b61e5a0-a5dc-4f66-b394-ed090d64ccde" />
